### PR TITLE
use ViewPropTypes instead of View.propTypes

### DIFF
--- a/KSYVideo.js
+++ b/KSYVideo.js
@@ -6,9 +6,11 @@ import {
     View,
     UIManager,
     findNodeHandle,
-    StyleSheet
+    StyleSheet,
+    ViewPropTypes
 }from 'react-native';
 var RCT_VIDEO_REF = 'KSYVideo';
+const KSYViewPropType = ViewPropTypes || View.propTypes;
 export default class KSYVideo extends Component {
     constructor(props) {
         super(props);
@@ -145,7 +147,7 @@ export default class KSYVideo extends Component {
 }
 KSYVideo.propTypes = {
     /* Native only */
-    style: View.propTypes.style,
+    style: KSYViewPropType.style,
     src: PropTypes.object,
     seek: PropTypes.number,
     onVideoTouch: PropTypes.func,
@@ -190,7 +192,7 @@ KSYVideo.propTypes = {
     onPlaybackStalled: PropTypes.func,
     onPlaybackResume: PropTypes.func,
 
-    ...View.propTypes,
+    ...KSYViewPropType,
 };
 
 const RCTKSYVideo = requireNativeComponent('RCTKSYVideo',KSYVideo,{


### PR DESCRIPTION
View.propTypes is deprecated in newer version of RN and causes app crashes in release mode
Replace this with ViewPropTypes to prevent crash