### PR TITLE
Remove android:allowBackup to prevent merge issues

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_SETTINGS"/>
 
-    <application android:allowBackup="true" android:label="@string/app_name"
+    <application android:label="@string/app_name"
         android:supportsRtl="true">
 
     </application>


### PR DESCRIPTION
Remove `android:allowBackup` to prevent issues with androidstudio/manifest-merger, especially as the value is now `false` by default in React Native:  https://github.com/facebook/react-native/commit/d7a9ca2